### PR TITLE
Use mvn dependency instead of install

### DIFF
--- a/build
+++ b/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn dependency:resolve -Dmaven.test.failure.ignore=true -DfailIfNoTests=false
+mvn dependency:resolve

--- a/build
+++ b/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn install -Dmaven.test.failure.ignore=true -DfailIfNoTests=false
+mvn dependency:resolve -Dmaven.test.failure.ignore=true -DfailIfNoTests=false


### PR DESCRIPTION
As pointed out by a contributor, `mvn install` will build the project but in most cases code is incomplete (in order to let learner complete them) and the project won't build.
